### PR TITLE
fix: 清空串口缓冲区避免初始化信息被当作用户输入

### DIFF
--- a/src/tests/test_runner.cpp
+++ b/src/tests/test_runner.cpp
@@ -164,6 +164,11 @@ void setup() {
   
   LOG_I("Test", "测试运行器初始化完成");
   Serial.println("=== 测试运行器初始化完成 ===");
+  
+  // 清空串口缓冲区，避免初始化信息被当作用户输入
+  while (Serial.available() > 0) {
+    Serial.read();
+  }
 }
 
 // 运行选定的测试


### PR DESCRIPTION
## 更改说明
- 在`setup()`函数末尾添加代码清空串口缓冲区
- 避免设备初始化信息被串口监视器当作用户输入处理
- 解决了启动时显示"无效输入，请重新输入。"的问题

## 测试说明
- 重新编译并上传代码到设备
- 通过串口监视器验证问题已解决
- 确认设备正常启动并显示测试菜单
