### PR TITLE
feat: 为 WiFi AP 连接增加重试功能和重试间隔递增管理

### DIFF
--- a/include/wifi_manager.h
+++ b/include/wifi_manager.h
@@ -66,6 +66,10 @@ private:
   unsigned long connectionStartTime;
   bool apModeEnabled;
   
+  // 重试相关变量
+  unsigned int retryCount;
+  unsigned long currentReconnectInterval;
+  
   // 超时跟踪变量
   unsigned long masterStartTime;
   bool masterTimeoutChecked;

--- a/src/wifi_manager.cpp
+++ b/src/wifi_manager.cpp
@@ -13,6 +13,8 @@ WiFiManager::WiFiManager() :
   lastConnectionAttempt(0),
   connectionStartTime(0),
   apModeEnabled(false),
+  retryCount(0),
+  currentReconnectInterval(RECONNECT_INTERVAL),
   masterStartTime(0),
   masterTimeoutChecked(false),
   slaveStartTime(0),
@@ -227,8 +229,18 @@ void WiFiManager::handle() {
   } else if (connectionStatus == WIFI_CONNECTION_FAILED) {
     // 尝试重连
     unsigned long currentTime = millis();
-    if (currentTime - lastConnectionAttempt > RECONNECT_INTERVAL) {
+    if (currentTime - lastConnectionAttempt > currentReconnectInterval) {
       lastConnectionAttempt = currentTime;
+      retryCount++;
+      
+      // 递增重连间隔，最大不超过300秒
+      currentReconnectInterval = RECONNECT_INTERVAL * retryCount;
+      if (currentReconnectInterval > 300000) { // 300秒 = 5分钟
+        currentReconnectInterval = 300000;
+      }
+      
+      Serial.printf("WiFiManager: Reconnect attempt %d, next interval %lu ms\n",
+                    retryCount, currentReconnectInterval);
       connect();
     }
   } else if (connectionStatus == WIFI_DISCONNECTED && device) {
@@ -285,6 +297,13 @@ void WiFiManager::onWiFiEvent(WiFiEvent_t event) {
 void WiFiManager::updateConnectionStatus(WiFiConnectionStatus status) {
   if (connectionStatus != status) {
     connectionStatus = status;
+    
+    // 如果连接成功，重置重试计数和重连间隔
+    if (status == WIFI_CONNECTED) {
+      retryCount = 0;
+      currentReconnectInterval = RECONNECT_INTERVAL;
+      Serial.println("WiFiManager: Connection successful, reset retry count");
+    }
     
     // 调用回调函数
     if (statusCallback) {


### PR DESCRIPTION
本次更改实现了 WiFi AP 连接的重试功能和重试间隔递增管理。主要变更包括：
1. 在 WiFiManager 类中添加了 retryCount 和 currentReconnectInterval 变量来管理重试次数和重连间隔
2. 修改了 handle() 方法中的重连逻辑，实现递增的重试间隔，每次重试间隔增加 30 秒，最大不超过 300 秒
3. 在连接成功时重置重试计数和重连间隔
4. 添加了相应的日志输出，方便调试和监控