### PR TITLE
修复TCP心跳包数据分离问题

### DIFF
--- a/src/heartbeat.cpp
+++ b/src/heartbeat.cpp
@@ -28,6 +28,7 @@ void Heartbeat::handle() {
         if (_wifiManager && _wifiManager->getConnectionStatus() == WIFI_CONNECTED &&
             _tcpProtocol && _tcpProtocol->getConnectionStatus() == TCP_CONNECTED) {
             _canStart = true;
+            _lastReceivedTime = millis(); // 重置最后接收时间
             LOG_I("Heartbeat", "WiFi and TCP connected, starting heartbeat detection");
         } else {
             // 如果连接状态不满足要求，保持心跳状态为断开
@@ -53,33 +54,52 @@ void Heartbeat::handle() {
     
     // 检查是否超时
     if (isTimeout()) {
-        LOG_W("Heartbeat", "Heartbeat timeout detected");
+      if (_status != HEARTBEAT_STATUS_TIMEOUT) {
+        LOG_W("Heartbeat", "Heartbeat timeout detected, last received time: %lu, current time: %lu, timeout: %lu",
+              _lastReceivedTime, millis(), HEARTBEAT_RECEIVE_TIMEOUT);
         _status = HEARTBEAT_STATUS_TIMEOUT;
+      }
+    } else {
+      // 如果没有超时，且之前是超时状态，则恢复连接状态
+      if (_status == HEARTBEAT_STATUS_TIMEOUT) {
+        _status = HEARTBEAT_CONNECTED;
+        LOG_I("Heartbeat", "Heartbeat recovered from timeout");
+      }
+      // 对于主设备，如果没有超时且有最近的接收时间，保持连接状态
+      else if (_device && _device->isMaster() && _status != HEARTBEAT_CONNECTED) {
+        unsigned long timeSinceLastReceived = millis() - _lastReceivedTime;
+        if (timeSinceLastReceived < HEARTBEAT_RECEIVE_TIMEOUT) {
+          _status = HEARTBEAT_CONNECTED;
+          LOG_D("Heartbeat", "Master device heartbeat status updated to Connected");
+        }
+      }
     }
     
     // 从设备发送心跳包
     if (!_device->isMaster()) {
-        unsigned long currentTime = millis();
-        if (currentTime - _lastHeartbeatTime > HEARTBEAT_INTERVAL) {
-            if (sendHeartbeat()) {
-                _lastHeartbeatTime = currentTime;
-                LOG_D("Heartbeat", "Heartbeat sent successfully");
-            } else {
-                LOG_W("Heartbeat", "Failed to send heartbeat");
-            }
+      unsigned long currentTime = millis();
+      if (currentTime - _lastHeartbeatTime > HEARTBEAT_SEND_INTERVAL) {
+        LOG_D("Heartbeat", "Sending heartbeat packet");
+        if (sendHeartbeat()) {
+          _lastHeartbeatTime = currentTime;
+          LOG_D("Heartbeat", "Heartbeat sent successfully");
+        } else {
+          LOG_W("Heartbeat", "Failed to send heartbeat");
         }
+      }
     }
-}
+  }
 
 bool Heartbeat::sendHeartbeat() {
     if (_device->isMaster()) {
         // 主设备不需要发送心跳包
+        LOG_D("Heartbeat", "Master device does not send heartbeat packets");
         return true;
     }
     
     // 检查TCP连接状态
     if (!_tcpProtocol || _tcpProtocol->getConnectionStatus() != TCP_CONNECTED) {
-        LOG_E("Heartbeat", "TCP connection not available");
+        LOG_E("Heartbeat", "TCP connection not available for sending heartbeat");
         _status = HEARTBEAT_DISCONNECTED;
         return false;
     }
@@ -87,26 +107,50 @@ bool Heartbeat::sendHeartbeat() {
     // 构造心跳包数据
     // 使用特殊的数据包类型标识心跳包
     uint8_t heartbeatData[4];
-    heartbeatData[0] = (HEARTBEAT_PACKET_TYPE >> 8) & 0xFF;  // 高字节
-    heartbeatData[1] = HEARTBEAT_PACKET_TYPE & 0xFF;        // 低字节
+    heartbeatData[0] = (HEARTBEAT_PACKET_TYPE >> 8) & 0xFF;  // 高字节 (0xFF)
+    heartbeatData[1] = HEARTBEAT_PACKET_TYPE & 0xFF;        // 低字节 (0x01)
     heartbeatData[2] = 'P';
     heartbeatData[3] = 'I';
     
+    LOG_D("Heartbeat", "Sending heartbeat packet with type: 0x%04X", HEARTBEAT_PACKET_TYPE);
+    
     // 通过TCP协议发送心跳包
     if (_tcpProtocol->sendData(heartbeatData, sizeof(heartbeatData))) {
-        _lastReceivedTime = millis();
+        _lastHeartbeatTime = millis();  // 更新发送时间而不是接收时间
         _status = HEARTBEAT_CONNECTED;
+        LOG_D("Heartbeat", "Heartbeat packet sent successfully");
         return true;
     } else {
         LOG_E("Heartbeat", "Failed to send heartbeat packet");
+        _status = HEARTBEAT_STATUS_TIMEOUT; // 发送失败也标记为超时
         return false;
     }
 }
 
+void Heartbeat::updateLastReceivedTime() {
+    unsigned long currentTime = millis();
+    // 只有在当前时间比最后接收时间晚的情况下才更新
+    // 这样可以避免在短时间内多次更新
+    if (currentTime > _lastReceivedTime) {
+        LOG_D("Heartbeat", "Updating last received time from %lu to %lu", _lastReceivedTime, currentTime);
+        _lastReceivedTime = currentTime;
+    }
+}
+
 void Heartbeat::handleHeartbeat() {
-    // 更新最后接收时间
-    _lastReceivedTime = millis();
+  LOG_D("Heartbeat", "Handling received heartbeat packet");
+  // 更新最后接收时间
+  unsigned long previousReceivedTime = _lastReceivedTime;
+  _lastReceivedTime = millis();
+  
+  // 对于主设备，接收到心跳包就表示连接正常
+  if (_device && _device->isMaster()) {
     _status = HEARTBEAT_CONNECTED;
+    LOG_I("Heartbeat", "Master device received heartbeat, status updated to Connected");
+  }
+  
+  LOG_D("Heartbeat", "Heartbeat packet handled, last received time updated from %lu to %lu, interval: %lu ms",
+        previousReceivedTime, _lastReceivedTime, _lastReceivedTime - previousReceivedTime);
 }
 
 HeartbeatStatus Heartbeat::getStatus() {
@@ -118,7 +162,7 @@ void Heartbeat::setStatus(HeartbeatStatus status) {
 }
 
 bool Heartbeat::isTimeout() {
-    return (millis() - _lastReceivedTime) > HEARTBEAT_TIMEOUT;
+    return (millis() - _lastReceivedTime) > HEARTBEAT_RECEIVE_TIMEOUT;
 }
 
 bool Heartbeat::reconnect() {

--- a/src/tcp_protocol.cpp
+++ b/src/tcp_protocol.cpp
@@ -12,7 +12,8 @@ TCPProtocol::TCPProtocol() :
   lastConnectionAttempt(0),
   connectionStartTime(0),
   statusCallback(nullptr),
-  receiveBufferIndex(0) {
+  receiveBufferIndex(0),
+  incompletePacketSize(0) {
 }
 
 TCPProtocol::~TCPProtocol() {
@@ -45,14 +46,14 @@ bool TCPProtocol::begin(Device* device, RS485* rs485, MDNSService* mdnsService) 
     LOG_I("TCPProtocol", "Client mode initialized");
   }
   
+  LOG_I("TCPProtocol", "TCPProtocol initialized successfully for %s device",
+        this->device->isMaster() ? "master" : "slave");
   return true;
 }
 
 void TCPProtocol::setHeartbeat(Heartbeat* heartbeat) {
   this->heartbeat = heartbeat;
 }
-
-
 void TCPProtocol::handle() {
   // 处理TCP连接和数据传输
   if (device->isMaster()) {
@@ -67,7 +68,8 @@ void TCPProtocol::handle() {
   if (connectionStatus == TCP_CONNECTING) {
     // 检查连接是否超时
     if (isConnectionTimedOut()) {
-      LOG_E("TCPProtocol", "Connection timeout");
+      LOG_E("TCPProtocol", "Connection timeout, connection start time: %lu, current time: %lu, timeout: %lu",
+            connectionStartTime, millis(), CONNECTION_TIMEOUT);
       updateConnectionStatus(TCP_CONNECTION_FAILED);
       if (client.connected()) {
         client.stop();
@@ -78,10 +80,20 @@ void TCPProtocol::handle() {
     if (!device->isMaster()) {
       unsigned long currentTime = millis();
       if (currentTime - lastConnectionAttempt > RECONNECT_INTERVAL) {
+        LOG_I("TCPProtocol", "Attempting to reconnect to master, last attempt: %lu, current time: %lu, interval: %lu",
+              lastConnectionAttempt, currentTime, RECONNECT_INTERVAL);
         lastConnectionAttempt = currentTime;
         connectToMaster();
       }
     }
+  }
+  
+  // 定期记录连接状态（仅在调试级别）
+  static unsigned long lastStatusLogTime = 0;
+  unsigned long currentTime = millis();
+  if (currentTime - lastStatusLogTime > 30000) { // 每30秒记录一次
+    LOG_D("TCPProtocol", "Current connection status: %s", getConnectionStatusString().c_str());
+    lastStatusLogTime = currentTime;
   }
 }
 
@@ -188,16 +200,28 @@ bool TCPProtocol::sendPacket(const uint8_t* data, size_t length) {
   }
   
   // 构造数据包头部
-  PacketHeader header;
-  header.length = length;
-  header.checksum = calculateChecksum(data, length);
+  uint16_t packetLength = length;
+  uint16_t packetChecksum = calculateChecksum(data, length);
+  
+  LOG_D("TCPProtocol", "Sending packet with length: %d, checksum: %d", packetLength, packetChecksum);
+  
+  // 手动构造头部字节数组，使用小端序
+  uint8_t headerBytes[PACKET_HEADER_SIZE];
+  headerBytes[0] = packetLength & 0xFF;        // 长度低字节
+  headerBytes[1] = (packetLength >> 8) & 0xFF; // 长度高字节
+  headerBytes[2] = packetChecksum & 0xFF;      // 校验和低字节
+  headerBytes[3] = (packetChecksum >> 8) & 0xFF; // 校验和高字节
   
   // 发送头部
-  size_t headerSent = client.write((uint8_t*)&header, PACKET_HEADER_SIZE);
+  size_t headerSent = client.write(headerBytes, PACKET_HEADER_SIZE);
   if (headerSent != PACKET_HEADER_SIZE) {
     REPORT_ERROR(ERROR_TCP_SEND_FAILED, "TCPProtocol", "Failed to send packet header");
     return false;
   }
+  
+  // 确保头部发送完成
+  client.flush();
+  LOG_D("TCPProtocol", "Packet header sent and flushed");
   
   // 发送数据
   size_t dataSent = client.write(data, length);
@@ -208,10 +232,11 @@ bool TCPProtocol::sendPacket(const uint8_t* data, size_t length) {
   
   // 确保数据发送完成
   client.flush();
+  LOG_D("TCPProtocol", "Packet data sent and flushed");
   
+  LOG_D("TCPProtocol", "Packet sent successfully");
   return true;
 }
-
 int TCPProtocol::receivePacket(uint8_t* buffer, size_t bufferSize) {
   if (!buffer || bufferSize == 0) {
     REPORT_ERROR(ERROR_INVALID_PARAMETER, "TCPProtocol", "Invalid buffer or size for packet reception");
@@ -219,9 +244,111 @@ int TCPProtocol::receivePacket(uint8_t* buffer, size_t bufferSize) {
   }
   
   // 检查连接状态
+  LOG_D("TCPProtocol", "Checking connection status for packet reception");
   if (!client.connected()) {
     REPORT_ERROR(ERROR_TCP_CONNECTION_FAILED, "TCPProtocol", "Client not connected for packet reception");
     return -1;
+  }
+  
+  // 检查是否有之前保存的不完整数据包
+  if (incompletePacketSize > 0) {
+    // 检查是否有足够的数据来完成之前不完整的数据包
+    if (client.available() >= (int)(incompletePacketHeader.length - incompletePacketSize)) {
+      // 读取剩余的数据
+      size_t remainingBytes = incompletePacketHeader.length - incompletePacketSize;
+      size_t dataRead = client.readBytes(incompletePacketBuffer + incompletePacketSize, remainingBytes);
+      if (dataRead != remainingBytes) {
+        REPORT_ERROR(ERROR_TCP_RECEIVE_FAILED, "TCPProtocol", "Failed to read remaining packet data");
+        incompletePacketSize = 0; // 重置不完整数据包状态
+        return -1;
+      }
+      
+      // 更新不完整数据包大小
+      incompletePacketSize += dataRead;
+      
+      // 验证校验和
+      uint16_t calculatedChecksum = calculateChecksum(incompletePacketBuffer, incompletePacketHeader.length);
+      if (calculatedChecksum != incompletePacketHeader.checksum) {
+        REPORT_ERROR(ERROR_TCP_RECEIVE_FAILED, "TCPProtocol", "Checksum mismatch for incomplete packet");
+        incompletePacketSize = 0; // 重置不完整数据包状态
+        return -1;
+      }
+      
+      // 检查是否为心跳包
+      if (isHeartbeatPacket(incompletePacketBuffer, incompletePacketSize)) {
+        handleHeartbeatPacket(incompletePacketBuffer, incompletePacketSize);
+        // 重置不完整数据包状态
+        incompletePacketSize = 0;
+        // 心跳包不需要返回给应用层
+        return -2; // 特殊返回值表示处理了心跳包但没有应用数据
+      }
+      
+      // 将数据复制到输出缓冲区
+      if (incompletePacketHeader.length > bufferSize) {
+        REPORT_ERROR(ERROR_TCP_RECEIVE_FAILED, "TCPProtocol", "Buffer too small for packet data");
+        incompletePacketSize = 0; // 重置不完整数据包状态
+        return -1;
+      }
+      
+      memcpy(buffer, incompletePacketBuffer, incompletePacketHeader.length);
+      size_t packetSize = incompletePacketHeader.length;
+      
+      // 重置不完整数据包状态
+      incompletePacketSize = 0;
+      
+      return packetSize;
+    } else {
+      // 仍然没有足够的数据，继续读取
+      size_t availableBytes = client.available();
+      if (availableBytes > 0) {
+        size_t dataRead = client.readBytes(incompletePacketBuffer + incompletePacketSize, availableBytes);
+        incompletePacketSize += dataRead;
+        
+        // 检查新读取的数据中是否包含心跳包
+        // 我们需要检查从incompletePacketSize - dataRead到incompletePacketSize的范围
+        // 但由于心跳包可能跨越之前的不完整数据和新读取的数据，我们需要检查整个缓冲区
+        bool heartbeatProcessed = false;
+        if (incompletePacketSize >= 4) {
+          // 检查缓冲区中是否包含心跳包
+          for (size_t i = 0; i <= incompletePacketSize - 4; i++) {
+            if (isHeartbeatPacket(incompletePacketBuffer + i, incompletePacketSize - i)) {
+              // 找到心跳包，处理它
+              handleHeartbeatPacket(incompletePacketBuffer + i, 4);
+              
+              // 移除已处理的心跳包数据
+              if (i + 4 < incompletePacketSize) {
+                // 还有剩余数据，移动到缓冲区开始
+                memmove(incompletePacketBuffer, incompletePacketBuffer + i + 4, incompletePacketSize - i - 4);
+                incompletePacketSize -= (i + 4);
+              } else {
+                // 没有剩余数据
+                incompletePacketSize = 0;
+              }
+              
+              // 标记已处理心跳包
+              heartbeatProcessed = true;
+              
+              // 心跳包不需要返回给应用层
+              // 如果缓冲区中没有其他数据，返回特殊值
+              // 如果还有其他数据，可能需要进一步处理
+              break;
+            }
+          }
+        }
+        
+        // 如果处理了心跳包但没有其他数据，返回特殊值
+        if (heartbeatProcessed && incompletePacketSize == 0) {
+          // 更新最后接收时间
+          if (heartbeat) {
+            heartbeat->updateLastReceivedTime();
+          }
+          return -2; // 特殊返回值表示处理了心跳包但没有应用数据
+        }
+      }
+      
+      // 仍然没有完整的数据包
+      return 0;
+    }
   }
   
   // 检查是否有足够的数据可读（至少包含头部）
@@ -229,13 +356,20 @@ int TCPProtocol::receivePacket(uint8_t* buffer, size_t bufferSize) {
     return 0; // 没有完整的数据包
   }
   
-  // 读取数据包头部
-  PacketHeader header;
-  size_t headerRead = client.readBytes((uint8_t*)&header, PACKET_HEADER_SIZE);
+  // 读取数据包头部 - 使用字节数组避免结构体对齐问题
+  uint8_t headerBytes[PACKET_HEADER_SIZE];
+  size_t headerRead = client.readBytes(headerBytes, PACKET_HEADER_SIZE);
   if (headerRead != PACKET_HEADER_SIZE) {
     REPORT_ERROR(ERROR_TCP_RECEIVE_FAILED, "TCPProtocol", "Failed to read packet header");
     return -1;
   }
+  
+  // 手动解析头部数据，避免字节序和对齐问题
+  PacketHeader header;
+  header.length = (headerBytes[1] << 8) | headerBytes[0];    // 小端序
+  header.checksum = (headerBytes[3] << 8) | headerBytes[2];  // 小端序
+  
+  LOG_D("TCPProtocol", "Received packet header - length: %d, checksum: %d", header.length, header.checksum);
   
   // 检查数据包长度是否有效
   if (header.length == 0 || header.length > MAX_PACKET_SIZE) {
@@ -248,12 +382,66 @@ int TCPProtocol::receivePacket(uint8_t* buffer, size_t bufferSize) {
     REPORT_ERROR(ERROR_TCP_RECEIVE_FAILED, "TCPProtocol", "Buffer too small for packet data");
     return -1;
   }
-  
   // 检查是否有足够的数据可读
   if (client.available() < header.length) {
-    // 数据不完整，重新放回头部数据（这里简化处理，实际应用中可能需要更复杂的缓冲区管理）
-    LOG_W("TCPProtocol", "Incomplete packet data");
-    return 0;
+    // 数据不完整，保存头部信息
+    incompletePacketHeader = header;
+    size_t availableBytes = client.available();
+    
+    LOG_W("TCPProtocol", "Incomplete packet data, header length: %d, available data: %d", header.length, availableBytes);
+    
+    // 对于小数据包（如心跳包），尝试多次等待数据到达
+    if (header.length <= 16) {
+      int retryCount = 0;
+      const int maxRetries = 10; // 增加重试次数
+      const int retryDelay = 10; // 增加延迟时间
+      
+      LOG_D("TCPProtocol", "Small packet detected (length: %d), starting retry mechanism", header.length);
+      
+      while (retryCount < maxRetries && client.available() < header.length) {
+        delay(retryDelay);
+        retryCount++;
+        availableBytes = client.available();
+        LOG_D("TCPProtocol", "Retry %d/%d: available data: %d (need: %d)", retryCount, maxRetries, availableBytes, header.length);
+        
+        // 如果数据已经足够，跳出循环
+        if (availableBytes >= header.length) {
+          LOG_I("TCPProtocol", "Complete data arrived after %d retries", retryCount);
+          break;
+        }
+      }
+      
+      // 重新检查数据可用性
+      if (client.available() >= header.length) {
+        // 数据已经到达，继续正常处理
+        LOG_D("TCPProtocol", "Data arrived after %d retries, proceeding with normal processing", retryCount);
+      } else {
+        // 仍然没有足够数据，但如果是心跳包长度，特殊处理
+        if (header.length == 4 && availableBytes == 0) {
+          LOG_W("TCPProtocol", "Heartbeat packet data still missing after %d retries, this may indicate a network issue", retryCount);
+        }
+        
+        // 保存到不完整缓冲区
+        if (availableBytes > 0) {
+          size_t dataRead = client.readBytes(incompletePacketBuffer, availableBytes);
+          incompletePacketSize = dataRead;
+          LOG_D("TCPProtocol", "Saved %d bytes to incomplete buffer (expected: %d)", dataRead, header.length);
+        } else {
+          incompletePacketSize = 0;
+        }
+        return 0;
+      }
+    } else {
+      // 对于大数据包，直接保存到不完整缓冲区
+      if (availableBytes > 0) {
+        size_t dataRead = client.readBytes(incompletePacketBuffer, availableBytes);
+        incompletePacketSize = dataRead;
+        LOG_D("TCPProtocol", "Large packet: saved %d bytes to incomplete buffer", dataRead);
+      } else {
+        incompletePacketSize = 0;
+      }
+      return 0;
+    }
   }
   
   // 读取数据
@@ -274,7 +462,7 @@ int TCPProtocol::receivePacket(uint8_t* buffer, size_t bufferSize) {
   if (isHeartbeatPacket(buffer, dataRead)) {
     handleHeartbeatPacket(buffer, dataRead);
     // 心跳包不需要返回给应用层
-    return 0;
+    return -2; // 特殊返回值表示处理了心跳包但没有应用数据
   }
   
   return dataRead;
@@ -292,9 +480,15 @@ bool TCPProtocol::isHeartbeatPacket(const uint8_t* data, size_t length) {
 }
 
 void TCPProtocol::handleHeartbeatPacket(const uint8_t* data, size_t length) {
+  LOG_D("TCPProtocol", "Handling heartbeat packet with length: %d", length);
   // 如果有心跳模块，调用心跳模块的处理函数
   if (heartbeat) {
     heartbeat->handleHeartbeat();
+    // 确保更新最后接收时间
+    heartbeat->updateLastReceivedTime();
+    LOG_D("TCPProtocol", "Heartbeat packet handled successfully");
+  } else {
+    LOG_W("TCPProtocol", "Heartbeat module not available");
   }
 }
 
@@ -304,7 +498,7 @@ void TCPProtocol::handleServer() {
   }
   
   // 检查是否有新的客户端连接
-  WiFiClient newClient = server->available();
+  WiFiClient newClient = server->accept();
   if (newClient) {
     if (!client.connected()) {
       // 接受新连接
@@ -322,7 +516,7 @@ void TCPProtocol::handleServer() {
   if (client.connected()) {
     // 检查是否有来自RS485的数据需要转发到TCP客户端
     if (rs485->available()) {
-      uint8_t buffer[256];
+      uint8_t buffer[1024];
       int bytesRead = rs485->receive(buffer, sizeof(buffer));
       if (bytesRead > 0) {
         // 发送到TCP客户端
@@ -332,11 +526,17 @@ void TCPProtocol::handleServer() {
     
     // 检查是否有来自TCP客户端的数据需要转发到RS485
     if (client.available()) {
-      uint8_t buffer[256];
+      uint8_t buffer[1024];
       int bytesRead = receiveData(buffer, sizeof(buffer));
       if (bytesRead > 0) {
         // 发送到RS485
         rs485->send(buffer, bytesRead);
+      } else if (bytesRead == 0) {
+        // 没有完整数据包，但连接是活跃的
+        LOG_D("TCPProtocol", "No complete packet available, but connection is active");
+      } else if (bytesRead == -2) {
+        // 处理了心跳包但没有应用数据
+        LOG_D("TCPProtocol", "Heartbeat packet processed successfully");
       }
     }
   } else {
@@ -360,7 +560,7 @@ void TCPProtocol::handleClient() {
     
     // 检查是否有来自RS485的数据需要转发到主设备
     if (rs485->available()) {
-      uint8_t buffer[256];
+      uint8_t buffer[1024];
       int bytesRead = rs485->receive(buffer, sizeof(buffer));
       if (bytesRead > 0) {
         // 发送到主设备
@@ -370,11 +570,17 @@ void TCPProtocol::handleClient() {
     
     // 检查是否有来自主设备的数据需要转发到RS485
     if (client.available()) {
-      uint8_t buffer[256];
+      uint8_t buffer[1024];
       int bytesRead = receiveData(buffer, sizeof(buffer));
       if (bytesRead > 0) {
         // 发送到RS485
         rs485->send(buffer, bytesRead);
+      } else if (bytesRead == 0) {
+        // 没有完整数据包，但连接是活跃的
+        LOG_D("TCPProtocol", "No complete packet available, but connection is active");
+      } else if (bytesRead == -2) {
+        // 处理了心跳包但没有应用数据
+        LOG_D("TCPProtocol", "Heartbeat packet processed successfully");
       }
     }
   }


### PR DESCRIPTION
## 问题描述
在TCP流式传输中，心跳包的头部和数据部分可能在不同时间到达，导致主设备收到包头但数据部分丢失。

## 解决方案
1. 实现增强的重试机制，对小数据包（如心跳包）最多进行10次重试，每次延迟10ms
2. 优化TCP协议的数据包发送和接收逻辑，确保头部和数据正确传输
3. 添加详细的调试日志，便于跟踪数据包传输过程
4. 修复心跳包构造中的字节序问题，确保正确识别心跳包

## 技术细节
- 增强的重试机制：最多10次重试，每次10ms延迟（总计100ms等待时间）
- 智能小包处理：对≤16字节的小数据包采用积极等待策略
- 完整的缓冲区管理：改进不完整数据包的保存和重组逻辑
- 详细的诊断日志：实时跟踪重试过程和数据到达情况

## 验证结果
通过实际测试验证，修复后的心跳包能够正确接收和处理，系统稳定性显著提升。